### PR TITLE
Update GitHub workflow to run unit tests on local chain (UMA protocol)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,10 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 14.15.0
+      - name: Check out minter repository
+        uses: actions/checkout@v2
+        with:
+          path: ./minter
       - name: Check out protocol repository
         uses: actions/checkout@v2
         with:
@@ -25,11 +29,7 @@ jobs:
           yarn qbuild
           npx ganache-cli -p 9545 -e 1000000 -l 10000000 &
           yarn truffle migrate --network test
-      - name: Check out minter repository
-        uses: actions/checkout@v2
-        with:
-          path: ./minter
-      - name: Install deps and compile
+      - name: Install minter deps and compile
         run: |
           cd ./minter
           npm i

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,10 +13,11 @@ jobs:
         with:
           repository: halodao/protocol
           path: protocol
+      - name: Install Prereqs
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev libusb-1.0-0-dev yarn
       - name: Setup protocol, start chain and migrate
         run: |
           cd protocol
-          rm yarn.lock
           yarn
           yarn qbuild
           npx ganache-cli -p 9545 -e 1000000 -l 10000000 &

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,14 +13,14 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: halodao/protocol
-          path: protocol
+          path: ./protocol
       - name: Install Prereqs
         run: |
           sudo apt-get update
           sudo apt-get install -y libudev-dev libusb-1.0-0-dev yarn
       - name: Setup protocol, start chain and migrate
         run: |
-          cd protocol
+          cd ./protocol
           yarn
           yarn qbuild
           npx ganache-cli -p 9545 -e 1000000 -l 10000000 &
@@ -28,15 +28,15 @@ jobs:
       - name: Check out minter repository
         uses: actions/checkout@v2
         with:
-          path: minter
+          path: ./minter
       - name: Install deps and compile
         run: |
-          cd minter
+          cd ./minter
           npm i
           npm run compile
       - name: Run local tests
         env:
           CHAIN_NETWORK: ${{ secrets.CHAIN_NETWORK }}
         run: |
-          cd minter
+          cd ./minter
           npm run test:local

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Setup protocol, start chain and migrate
         run: |
           cd protocol
+          rm yarn.lock
           yarn
           yarn qbuild
           npx ganache-cli -p 9545 -e 1000000 -l 10000000 &

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,9 @@ jobs:
           repository: halodao/protocol
           path: protocol
       - name: Install Prereqs
-        run: sudo apt-get update && sudo apt-get install -y libudev-dev libusb-1.0-0-dev yarn
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libudev-dev libusb-1.0-0-dev yarn
       - name: Setup protocol, start chain and migrate
         run: |
           cd protocol
@@ -22,7 +24,6 @@ jobs:
           yarn qbuild
           npx ganache-cli -p 9545 -e 1000000 -l 10000000 &
           yarn truffle migrate --network test
-          cd ../
       - name: Check out minter repository
         uses: actions/checkout@v2
         with:
@@ -33,4 +34,6 @@ jobs:
           npm i
           npm run compile
       - name: Run local tests
-        run: npm run test:local
+        run: |
+          cd minter
+          npm run test:local

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,6 +3,7 @@ on: [push]
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    environment: test
     steps:
       - name: Switch to Node.js v14.15.0
         uses: actions/setup-node@v1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,6 +35,8 @@ jobs:
           npm i
           npm run compile
       - name: Run local tests
+        env:
+          CHAIN_NETWORK: ${{ secrets.CHAIN_NETWORK }}
         run: |
           cd minter
           npm run test:local

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,15 +4,31 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Switch Node.js version
+      - name: Switch to Node.js v14.15.0
         uses: actions/setup-node@v1
         with:
           node-version: 14.15.0
-      - name: Compile & test contracts
-        run: npm i && npm run compile && npm test
-      - name: Run node & deploy contracts
-        run: npm run node & npm run deploy:local
-      - name: Test & build frontend
-        run: cd frontend && npm i && CI=true npm test && npm run build
+      - name: Check out protocol repository
+        uses: actions/checkout@v2
+        with:
+          repository: halodao/protocol
+          path: protocol
+      - name: Setup protocol, start chain and migrate
+        run: |
+          cd protocol
+          yarn
+          yarn qbuild
+          npx ganache-cli -p 9545 -e 1000000 -l 10000000 &
+          yarn truffle migrate --network test
+          cd ../
+      - name: Check out minter repository
+        uses: actions/checkout@v2
+        with:
+          path: minter
+      - name: Install deps and compile
+        run: |
+          cd minter
+          npm i
+          npm run compile
+      - name: Run local tests
+        run: npm run test:local


### PR DESCRIPTION
This PR fixes [BGM-605 [Minter] Adjust github workflow settings for CI/CD](https://lifemesh.atlassian.net/browse/BGM-605)

On every push to this repo (any brach), we do the following:

1. checkout protocol repo > install deps, start chain & migrate
2. checkout this repo, install deps and run unit test (against the protocol chain)